### PR TITLE
Fix: Ticket 패키지 버그 수정

### DIFF
--- a/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/controller/TicketController.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/controller/TicketController.kt
@@ -40,7 +40,7 @@ class TicketController(
     }
 
     @Operation(summary = "멤버 티켓리스트 조회")
-    @GetMapping("/{userId}")
+    @GetMapping("/get/{userId}")
     fun getTicketListByUserId(
         @PageableDefault(
             size = 15, sort = ["id"]
@@ -63,13 +63,13 @@ class TicketController(
 //            .body(ticketService.updateTicket(request))
 //    }
     @Operation(summary = "티켓 삭제")
-    @DeleteMapping("/{ticketId}")
+    @DeleteMapping("/delete/{ticketId}")
     fun deleteTicket(
         @PathVariable ticketId: Long,
         @AuthenticationPrincipal user: UserPrincipal
     ): ResponseEntity<Unit> {
         return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
+            .status(HttpStatus.OK)
             .body(ticketService.deleteTicket(ticketId, user))
     }
 

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/entity/Ticket.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/entity/Ticket.kt
@@ -2,13 +2,14 @@ package com.codersgate.ticketraider.domain.ticket.entity
 
 import com.codersgate.ticketraider.domain.event.model.Event
 import com.codersgate.ticketraider.domain.member.entity.Member
+import com.codersgate.ticketraider.global.common.BaseEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import java.util.Date
 
 @Table(name = "tickets")
-@SQLDelete(sql = "UPDATE category SET is_deleted = true WHERE id = ?") // DELETE 쿼리 날아올 시 대신 실행
+@SQLDelete(sql = "UPDATE tickets SET is_deleted = true WHERE id = ?") // DELETE 쿼리 날아올 시 대신 실행
 @SQLRestriction("is_deleted = false")
 @Entity
 class Ticket(
@@ -33,7 +34,7 @@ class Ticket(
     @JoinColumn(name = "member_id", nullable = false)
     val member: Member
 
-) {
+): BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/repository/CustomTicketRepository.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/repository/CustomTicketRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable
 
 interface CustomTicketRepository {
 
-    fun findByUserId(pageable: Pageable, userId: Long): Page<Ticket>
+    fun getListByUserId(pageable: Pageable, userId: Long): Page<Ticket>
 }

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/repository/TicketRepositoryImpl.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/repository/TicketRepositoryImpl.kt
@@ -11,14 +11,19 @@ import org.springframework.data.domain.Pageable
 class TicketRepositoryImpl : QueryDslSupport(), CustomTicketRepository {
     private val ticket = QTicket.ticket
 
-    override fun findByUserId(pageable: Pageable, userId: Long): Page<Ticket> {
+    override fun getListByUserId(pageable: Pageable, userId: Long): Page<Ticket> {
 
+        val whereClause = BooleanBuilder()
+        whereClause.and(ticket.member.id.eq(userId))
         val totalCounts = queryFactory
             .select(ticket.count())
+            .where(whereClause)
             .from(ticket)
             .fetchOne() ?: 0L
 
         val contents = queryFactory.select(ticket)
+            .from(ticket)
+            .where(whereClause)
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .orderBy(ticket.date.desc())

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/service/TicketServiceImpl.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/ticket/service/TicketServiceImpl.kt
@@ -54,6 +54,6 @@ class TicketServiceImpl(
     }
 
     override fun getTicketListByUserId(userId: Long, pageable: Pageable): Page<TicketResponse> {
-        return ticketRepository.findByUserId(pageable, userId).map { TicketResponse.from(it) }
+        return ticketRepository.getListByUserId(pageable, userId).map { TicketResponse.from(it) }
     }
 }


### PR DESCRIPTION
#38 
- delete시 tickets가 아닌 category 업데이트하는 오류
- ambiguous method mapping(메소드 uri 중복) 오류 -> uri 수정
- 멤버의 티켓리스트 조회 안되는 오류 -> QueryDsl 코드 수정