### PR TITLE
Fix: Member 패키지 오류 수정

### DIFF
--- a/src/main/kotlin/com/codersgate/ticketraider/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/member/controller/MemberController.kt
@@ -54,10 +54,10 @@ class MemberController(
     }
 
     @Operation(summary = "프로필 수정")
-    @PreAuthorize("hasAnyRole('MEMBER')")
-    @PutMapping("/members/update")
+    @PreAuthorize("hasAnyRole('MEMBER', 'ADMIN')")
+    @PutMapping("/update")
     fun updateProfile(
-        @Valid @RequestParam memberRequest: MemberRequest,
+        @Valid @RequestBody memberRequest: MemberRequest,
         @AuthenticationPrincipal user: UserPrincipal
     ): ResponseEntity<Unit> {
         return ResponseEntity
@@ -66,7 +66,7 @@ class MemberController(
     }
 
     @Operation(summary = "회원 탈퇴")
-    @PreAuthorize("hasAnyRole('MEMBER')")
+    @PreAuthorize("hasAnyRole('MEMBER', 'ADMIN')")
     @DeleteMapping("/members/unregister")
     fun unregister(
         @AuthenticationPrincipal user: UserPrincipal

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/member/dto/MemberResponse.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/member/dto/MemberResponse.kt
@@ -1,18 +1,21 @@
 package com.codersgate.ticketraider.domain.member.dto
 
 import com.codersgate.ticketraider.domain.member.entity.Member
+import com.codersgate.ticketraider.domain.member.entity.MemberRole
 
 data class MemberResponse(
     val id: Long,
     val email: String,
-    val nickname: String
+    val nickname: String,
+    val role: MemberRole
 ) {
     companion object {
         fun from(member: Member): MemberResponse {
             return MemberResponse(
                 id = member.id!!,
                 email = member.email,
-                nickname = member.nickname
+                nickname = member.nickname,
+                role = member.role
             )
         }
     }

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/member/entity/Member.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/member/entity/Member.kt
@@ -11,7 +11,7 @@ import org.hibernate.annotations.SQLRestriction
 
 @Table(name = "members")
 @Entity
-@SQLDelete(sql = "UPDATE category SET is_deleted = true WHERE id = ?") // DELETE 쿼리 날아올 시 대신 실행
+@SQLDelete(sql = "UPDATE members SET is_deleted = true WHERE id = ?") // DELETE 쿼리 날아올 시 대신 실행
 @SQLRestriction("is_deleted = false")
 class Member(
     @Column(name = "email", unique = true)
@@ -41,10 +41,9 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
-    fun updateProfile(memberRequest: MemberRequest): Member {
+    fun updateProfile(memberRequest: MemberRequest) {
         this.email = memberRequest.email
         this.password = memberRequest.password
         this.nickname = memberRequest.nickname
-        return this
     }
 }

--- a/src/main/kotlin/com/codersgate/ticketraider/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/member/service/MemberServiceImpl.kt
@@ -62,10 +62,9 @@ class MemberServiceImpl(
 
     @Transactional
     override fun updateProfile(memberRequest: MemberRequest, user: UserPrincipal) {
-        val member = memberRepository.findByEmail(memberRequest.email)
+        val member = memberRepository.findByIdOrNull(user.id)
             ?: throw InvalidCredentialException("")
-        if (member.id != user.id) throw InvalidCredentialException("")
-        memberRepository.save(member.updateProfile(memberRequest))
+        member.updateProfile(memberRequest)
     }
 
     @Transactional


### PR DESCRIPTION
#41
- updateProfile에서 @RequestBody를 @RequestParam으로 잘못 설정
- 회원 탈퇴, 프로필 수정 권한 Member뿐만 아니라 Admin도 할 수 있게 수정
- delete 쿼리 update로 바꿀 떄 category로 잘못 들어가는 오류 수정
- MemberResponse에 MemberRole도 함께 표시