### PR TITLE
Fix: Member 패키지 컨트롤러의 메소드 url 수정

### DIFF
--- a/src/main/kotlin/com/codersgate/ticketraider/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/codersgate/ticketraider/domain/member/controller/MemberController.kt
@@ -41,7 +41,7 @@ class MemberController(
     }
 
     @Operation(summary = "프로필 조회")
-    @GetMapping("/members/{memberId}")
+    @GetMapping("/{memberId}")
     fun getProfile(
         @PathVariable memberId: Long
     ): ResponseEntity<MemberResponse> {
@@ -65,7 +65,7 @@ class MemberController(
 
     @Operation(summary = "회원 탈퇴")
     @PreAuthorize("hasAnyRole('MEMBER', 'ADMIN')")
-    @DeleteMapping("/members/unregister")
+    @DeleteMapping("/unregister")
     fun unregister(
         authentication: Authentication
     ): ResponseEntity<Unit> {


### PR DESCRIPTION
closes #94
- Member 패키지 updateProfile, register 메소드 url이 /members/members 와 같이 호출되던 것 수정